### PR TITLE
feat/#15: add root coordinator

### DIFF
--- a/omokwang/Projects/App/Sources/App.swift
+++ b/omokwang/Projects/App/Sources/App.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Root
 
 @main
 struct RootApp: App {
@@ -15,9 +16,7 @@ struct RootApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ZStack {
-                Text("Hello World")
-            }
+            RootView()
         }
     }
 }

--- a/omokwang/Projects/Presentation/Root/Sources/Coordinator/RootCoordinator.swift
+++ b/omokwang/Projects/Presentation/Root/Sources/Coordinator/RootCoordinator.swift
@@ -1,0 +1,37 @@
+//
+//  RootCoordinator.swift
+//  Root
+//
+//  Created by 김동준 on 8/24/24
+//
+
+import SwiftUI
+
+final class RootCoordinator: Hashable {
+    @Binding var navigationPath: NavigationPath
+    
+    private var id: UUID
+    var screen: RootScreen
+    
+    init(navigationPath: Binding<NavigationPath>, screen: RootScreen) {
+        self._navigationPath = navigationPath
+        self.id = UUID()
+        self.screen = screen
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    static func == (lhs: RootCoordinator, rhs: RootCoordinator) -> Bool {
+        lhs.id == rhs.id
+    }
+    
+    func push<V>(_ value: V) where V : Hashable {
+        navigationPath.append(value)
+    }
+    
+    func pop() {
+        navigationPath.removeLast()
+    }
+}

--- a/omokwang/Projects/Presentation/Root/Sources/Coordinator/RootCoordinatorView.swift
+++ b/omokwang/Projects/Presentation/Root/Sources/Coordinator/RootCoordinatorView.swift
@@ -1,0 +1,26 @@
+//
+//  RootCoordinatorView.swift
+//  Root
+//
+//  Created by 김동준 on 8/24/24
+//
+
+import SwiftUI
+
+extension RootCoordinator {
+    @ViewBuilder
+    func view() -> some View {
+        switch self.screen {
+        case .signIn:
+            signInView()
+        }
+    }
+}
+
+extension RootCoordinator {
+    private func signInView() -> some View {
+        return VStack {
+            Text("This is SignIn Example View")
+        }
+    }
+}

--- a/omokwang/Projects/Presentation/Root/Sources/Coordinator/RootScreen.swift
+++ b/omokwang/Projects/Presentation/Root/Sources/Coordinator/RootScreen.swift
@@ -1,0 +1,10 @@
+//
+//  RootScreen.swift
+//  Root
+//
+//  Created by 김동준 on 8/24/24
+//
+
+public enum RootScreen {
+    case signIn
+}

--- a/omokwang/Projects/Presentation/Root/Sources/DefaultSourceCode.swift
+++ b/omokwang/Projects/Presentation/Root/Sources/DefaultSourceCode.swift
@@ -1,1 +1,0 @@
-// default source code

--- a/omokwang/Projects/Presentation/Root/Sources/NavigationPath/RootNavigationPath.swift
+++ b/omokwang/Projects/Presentation/Root/Sources/NavigationPath/RootNavigationPath.swift
@@ -1,0 +1,16 @@
+//
+//  RootNavigationPath.swift
+//  Root
+//
+//  Created by 김동준 on 8/24/24
+//
+
+import SwiftUI
+
+final class RootNavigationPath: ObservableObject {
+    @Published var path: NavigationPath
+    
+    init(path: NavigationPath) {
+        self.path = path
+    }
+}

--- a/omokwang/Projects/Presentation/Root/Sources/RootView.swift
+++ b/omokwang/Projects/Presentation/Root/Sources/RootView.swift
@@ -1,0 +1,28 @@
+//
+//  RootView.swift
+//  Root
+//
+//  Created by 김동준 on 8/24/24
+//
+
+import SwiftUI
+
+public struct RootView: View {
+    @StateObject private var rootNavigationPath = RootNavigationPath(path: NavigationPath())
+    
+    public init() {}
+    
+    public var body: some View {
+        NavigationStack(path: $rootNavigationPath.path) {
+            Group {
+                RootCoordinator(
+                    navigationPath: $rootNavigationPath.path,
+                    screen: .signIn
+                ).view()
+            }
+            .navigationDestination(for: RootCoordinator.self) { coordinator in
+                coordinator.view()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Navigation 을 관리하는 RootCoordinator 생성.

앞에 Root를 붙인 이유는 TabView가 메인에 자리잡고 있기 때문에, 메인 페이지에서 MainCoordinator가 생성될 예정이므로 구분하기 위해 이름을 지어줌.

일단 SignIn에 대한 작업은 되어있지 않기 때문에, 해당 View 처리는 다른 브랜치(Sign In View)에서 할 예정